### PR TITLE
Reorder docker commands to get vagrant user in docker groups before…

### DIFF
--- a/scripts/build_dependencies.sh
+++ b/scripts/build_dependencies.sh
@@ -6,10 +6,10 @@ yum install -y tar git
 yum install -y epel-release
 yum update -y systemd
 yum install -y docker
-sudo service docker start
 sudo groupadd docker
 sudo usermod -a -G docker vagrant
 sudo usermod -a -G dockerroot vagrant
+sudo systemctl start docker
 
 # Install newer go Version
 sudo -u vagrant bash < <(curl -s -S -L https://raw.githubusercontent.com/moovweb/gvm/master/binscripts/gvm-installer) && \


### PR DESCRIPTION
...before starting docker

This fixes an issue where the build fails with:

```
Can't connect to 'docker' daemon.  please fix and retry.
```
